### PR TITLE
allow all hosts

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -2,6 +2,6 @@ module.exports = {
   devServer: {
     host: '0.0.0.0',
     port: 8000,
-    allowedHosts: ['.gtis.guru']
+    allowedHosts: ['all']
   }
 };


### PR DESCRIPTION
since we only use this for local dev I'm changing to allow "all" hosts

According to https://cli.vuejs.org/config/#devserver all the devServer options for the webpack server are supported, and according to https://webpack.js.org/configuration/dev-server/#devserverallowedhosts we can specify `all` to allow all hosts. This is not appropriate for prod, but since we don't run this as a docker image in prod this won't apply. 