### PR TITLE
Clarify root-level dependency versions in use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ start: deps
 deps:
 	docker-compose run --rm node npm install
 
+depsupdate:
+	docker-compose run --rm node npm update
+	docker-compose run --rm node npm ls --package-lock-only --json > installed-versions.json
+
 dist: deps
 	docker-compose run --rm node npm run build
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ See notes in Environment section regarding HTTPS and _traefik_ configuration.
 
 1.  When the `make` is run, the project will be in development mode and any updates made to the code will automatically be reloaded.
 
+### Updating dependencies
+
+Use `make depsupdate` if you want to update the npm dependencies. This command
+both does the npm update as well as updates our "installed-versions.json" file
+with what versions of our root-level dependencies are installed (to provide more
+human-readable diffs after updating npm dependencies).
+
 ### Running production version of the app locally
 
 1. Within `docker-compose.yml` change the `ui:` container's `command: npm run serve` to `command: npm run serve:prod`

--- a/installed-versions.json
+++ b/installed-versions.json
@@ -1,0 +1,85 @@
+{
+  "name": "idp-profile-ui",
+  "dependencies": {
+    "@babel/polyfill": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz"
+    },
+    "@simplewebauthn/browser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-4.1.0.tgz"
+    },
+    "@vue/cli-plugin-babel": {
+      "version": "4.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-4.5.15.tgz"
+    },
+    "@vue/cli-service": {
+      "version": "4.5.15",
+      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-4.5.15.tgz"
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz"
+    },
+    "babel-plugin-transform-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-imports/-/babel-plugin-transform-imports-2.0.0.tgz"
+    },
+    "date-fns": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz"
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
+    },
+    "sass-loader": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.2.0.tgz"
+    },
+    "sass": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.44.0.tgz"
+    },
+    "stylus-loader": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-4.3.3.tgz"
+    },
+    "stylus": {
+      "version": "0.54.8",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.8.tgz"
+    },
+    "vue-analytics": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.22.1.tgz"
+    },
+    "vue-cli-plugin-vuetify": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.4.4.tgz"
+    },
+    "vue-router": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.3.tgz"
+    },
+    "vue-template-compiler": {
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz"
+    },
+    "vue": {
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz"
+    },
+    "vuetify-loader": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/vuetify-loader/-/vuetify-loader-1.7.3.tgz"
+    },
+    "vuetify": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.1.tgz"
+    },
+    "zxcvbn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "idp-profile-ui",
-  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/silinternational/idp-profile-ui"


### PR DESCRIPTION
### Added
- Record root-level dependency versions currently in use
- Add `make depsupdate` command to update deps and record new versions (of root deps)

### Fixed
- Remove old/incorrect version number from package.json file