### PR TITLE
Show an error rather than silently failing if verifying a new MFA fails

### DIFF
--- a/src/2sv/key/Touch.vue
+++ b/src/2sv/key/Touch.vue
@@ -83,13 +83,18 @@ export default {
         return
       }
 
-      this.newSecurityKey = await add('webauthn')
-      let registrationCredential;
-      registrationCredential = await startRegistration({
-        excludeCredentials: [],
-        ...this.newSecurityKey.data.publicKey,
-      })
-      await this.handleKeyResponse(registrationCredential)
+      try {
+        this.newSecurityKey = await add('webauthn')
+        let registrationCredential;
+        registrationCredential = await startRegistration({
+          excludeCredentials: [],
+          ...this.newSecurityKey.data.publicKey,
+        })
+        await this.handleKeyResponse(registrationCredential)
+      } catch (error) {
+        this.error = true
+        console.error(error)
+      }
     },
   },
 }


### PR DESCRIPTION
### Fixed
- Show an error rather than silently failing if verifying a new MFA fails

---

The current error message isn't ideal for this situation, but I think it's better than silently failing:
> Something went wrong. Please make sure you have the key inserted correctly and wait for the blink before pressing. If your key did not blink, you may not have a supported browser and will need to skip this step. Please consider a more secure browser like Google Chrome. 