### PR TITLE
support multiple security keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "idp-profile-ui",
       "license": "MIT",
       "dependencies": {
         "@babel/polyfill": "^7.12.1",

--- a/src/2sv/codes/Intro.vue
+++ b/src/2sv/codes/Intro.vue
@@ -39,8 +39,8 @@ export default {
     mfa,
   }),
   computed: {
-    hasOtherTypes: vm => vm.mfa.totp.id || vm.mfa.u2f.id || vm.mfa.webauthn.length,
-    hasNoMfa: vm => ! (vm.mfa.totp.id || vm.mfa.u2f.id || vm.mfa.webauthn.length || vm.mfa.backup.id),
+    hasOtherTypes: vm => vm.mfa.totp.id || vm.mfa.u2f.id || vm.mfa.keys.length,
+    hasNoMfa: vm => ! (vm.mfa.totp.id || vm.mfa.u2f.id || vm.mfa.keys.length || vm.mfa.backup.id),
   },
   methods: {
     skip() {

--- a/src/2sv/codes/Intro.vue
+++ b/src/2sv/codes/Intro.vue
@@ -39,8 +39,8 @@ export default {
     mfa,
   }),
   computed: {
-    hasOtherTypes: vm => vm.mfa.totp.id || vm.mfa.u2f.id || vm.mfa.webauthn.id,
-    hasNoMfa: vm => ! (vm.mfa.totp.id || vm.mfa.u2f.id || vm.mfa.webauthn.id || vm.mfa.backup.id),
+    hasOtherTypes: vm => vm.mfa.totp.id || vm.mfa.u2f.id || vm.mfa.webauthn.length,
+    hasNoMfa: vm => ! (vm.mfa.totp.id || vm.mfa.u2f.id || vm.mfa.webauthn.length || vm.mfa.backup.id),
   },
   methods: {
     skip() {

--- a/src/2sv/routes.js
+++ b/src/2sv/routes.js
@@ -66,23 +66,14 @@ export default [
   {
     path: '/2sv/usb-security-key/intro',
     component: KeyIntro,
-    beforeEnter: (to, from, next) => {
-      skipWhen(mfa.u2f.id || mfa.webauthn.id, '/2sv/printable-backup-codes/intro', next)
-    }
   },
   {
     path: '/2sv/usb-security-key/insert',
     component: Insert,
-    beforeEnter: (to, from, next) => {
-      skipWhen(mfa.u2f.id || mfa.webauthn.id, '/2sv/printable-backup-codes/intro', next)
-    }
   },
   {
     path: '/2sv/usb-security-key/touch',
     component: Touch,
-    beforeEnter: (to, from, next) => {
-      skipWhen(mfa.u2f.id || mfa.webauthn.id, '/2sv/printable-backup-codes/intro', next)
-    }
   },
   {
     path: '/2sv/usb-security-key/confirmed',

--- a/src/global/mfa.js
+++ b/src/global/mfa.js
@@ -3,7 +3,7 @@ import Vue from 'vue'
 export const mfa = {
   totp: {},
   u2f: {},
-  webauthn: {},
+  webauthn: [],
   backup: {},
   numVerified: 0
 }
@@ -24,7 +24,7 @@ export const retrieve = async () => {
 
   mfa.totp = Object.assign({}, all.find(m => m.type === 'totp'))
   mfa.u2f = Object.assign({}, all.find(m => m.type === 'u2f'))
-  mfa.webauthn = Object.assign({}, all.find(m => m.type === 'webauthn'))
+  mfa.webauthn = all.filter(m => m.type === 'webauthn')
   mfa.backup = Object.assign({}, all.find(m => m.type === 'backupcode'))
   
   mfa.numVerified = numOfVerifiedMfas(mfa) // currently, the api only returns verified mfas

--- a/src/global/mfa.js
+++ b/src/global/mfa.js
@@ -3,7 +3,7 @@ import Vue from 'vue'
 export const mfa = {
   totp: {},
   u2f: {},
-  webauthn: [],
+  keys: [],
   backup: {},
   numVerified: 0
 }
@@ -24,7 +24,7 @@ export const retrieve = async () => {
 
   mfa.totp = Object.assign({}, all.find(m => m.type === 'totp'))
   mfa.u2f = Object.assign({}, all.find(m => m.type === 'u2f'))
-  mfa.webauthn = all.filter(m => m.type === 'webauthn')
+  mfa.keys = all.filter(m => m.type === 'webauthn')
   mfa.backup = Object.assign({}, all.find(m => m.type === 'backupcode'))
   
   mfa.numVerified = numOfVerifiedMfas(mfa) // currently, the api only returns verified mfas
@@ -34,7 +34,7 @@ function numOfVerifiedMfas(mfa) {
   let num = 0
 
   num += mfa.totp.id ? 1 : 0
-  num += mfa.u2f.id || mfa.webauthn.id ? 1 : 0
+  num += mfa.u2f.id || mfa.keys.length || 0
   num += mfa.backup.id ? 1 : 0
 
   return num

--- a/src/profile/Index.vue
+++ b/src/profile/Index.vue
@@ -41,16 +41,28 @@
         <TotpCard :meta="mfa.totp"/>
       </v-col>
 
-      <v-col v-if="mfa.webauthn?.length" cols="12" sm="6" md="4">
-        <SecurityKeyCard v-for="mfaKey in mfa.webauthn" :mfaKey="mfaKey"/>
+      <v-col v-if="mfa.webauthn.length" cols="12" sm="6" md="4">
+        <SecurityKeyCard isFirst="true" :numberOfKeys="mfa.webauthn.length" :mfaKey="mfa.webauthn[0]"/>
       </v-col>
 
-      <v-col v-else>
-        <SecurityKeyCard :mfaKey=[] />
-      </v-col>
+      <v-col v-else-if="mfa.webauthn.length === 0">
+        <SecurityKeyCard isFirst="true" :mfaKey=[] />
+      </v-col>  
 
       <v-col cols="12" sm="6" md="4">
         <BackupCodeCard :meta="mfa.backup"/>
+      </v-col>
+    </v-row>
+
+    <v-row v-if="mfa.webauthn.length > 1">
+      <v-col>
+        Security Keys
+      </v-col>
+    </v-row>
+
+    <v-row  v-if="mfa.webauthn.length > 1">
+      <v-col v-for="mfaKey in additionalKeys" cols="12" sm="6" md="4">
+        <SecurityKeyCard :mfaKey="mfaKey"/>
       </v-col>
     </v-row>
   </BasePage>
@@ -65,8 +77,8 @@ import SecurityKeyCard from './SecurityKeyCard'
 import BackupCodeCard from './BackupCodeCard'
 import DoNotDiscloseCard from './DoNotDiscloseCard'
 import Attribute from './Attribute'
-import { recoveryMethods, retrieve as retrieveMethods} from '@/global/recoveryMethods';
-import { mfa, retrieve as retrieveMfa } from '@/global/mfa';
+import { recoveryMethods, retrieve as retrieveMethods} from '@/global/recoveryMethods'
+import { mfa, retrieve as retrieveMfa } from '@/global/mfa'
 
 export default {
   components: {
@@ -85,6 +97,7 @@ export default {
   }),
   computed: {
     hasUnverifiedEmails: vm => vm.alternates.some(m => ! m.verified),
+    additionalKeys: vm => vm.mfa.webauthn.slice(1),
   },
   async created() {
     await Promise.all([retrieveMethods(), retrieveMfa()])

--- a/src/profile/Index.vue
+++ b/src/profile/Index.vue
@@ -41,8 +41,12 @@
         <TotpCard :meta="mfa.totp"/>
       </v-col>
 
-      <v-col cols="12" sm="6" md="4">
-        <SecurityKeyCard :meta="mfa.webauthn"/>
+      <v-col v-if="mfa.webauthn?.length" cols="12" sm="6" md="4">
+        <SecurityKeyCard v-for="mfaKey in mfa.webauthn" :mfaKey="mfaKey"/>
+      </v-col>
+
+      <v-col v-else>
+        <SecurityKeyCard :mfaKey=[] />
       </v-col>
 
       <v-col cols="12" sm="6" md="4">

--- a/src/profile/Index.vue
+++ b/src/profile/Index.vue
@@ -41,11 +41,11 @@
         <TotpCard :meta="mfa.totp"/>
       </v-col>
 
-      <v-col v-if="mfa.webauthn.length" cols="12" sm="6" md="4">
-        <SecurityKeyCard isFirst="true" :numberOfKeys="mfa.webauthn.length" :mfaKey="mfa.webauthn[0]"/>
+      <v-col v-if="numberOfKeys" cols="12" sm="6" md="4">
+        <SecurityKeyCard isFirst="true" :numberOfKeys="numberOfKeys" :mfaKey="mfa.webauthn[0]"/>
       </v-col>
 
-      <v-col v-else-if="mfa.webauthn.length === 0">
+      <v-col v-else-if="numberOfKeys === 0">
         <SecurityKeyCard isFirst="true" :mfaKey=[] />
       </v-col>  
 
@@ -54,15 +54,15 @@
       </v-col>
     </v-row>
 
-    <v-row v-if="mfa.webauthn.length > 1">
+    <v-row v-if="numberOfKeys > 1">
       <v-col>
         Security Keys
       </v-col>
     </v-row>
 
-    <v-row  v-if="mfa.webauthn.length > 1">
+    <v-row  v-if="numberOfKeys > 1">
       <v-col v-for="mfaKey in additionalKeys" cols="12" sm="6" md="4">
-        <SecurityKeyCard :mfaKey="mfaKey"/>
+        <SecurityKeyCard :mfaKey="mfaKey" :numberOfKeys="numberOfKeys"/>
       </v-col>
     </v-row>
   </BasePage>
@@ -98,6 +98,7 @@ export default {
   computed: {
     hasUnverifiedEmails: vm => vm.alternates.some(m => ! m.verified),
     additionalKeys: vm => vm.mfa.webauthn.slice(1),
+    numberOfKeys: vm => mfa.webauthn.length
   },
   async created() {
     await Promise.all([retrieveMethods(), retrieveMfa()])

--- a/src/profile/Index.vue
+++ b/src/profile/Index.vue
@@ -42,7 +42,7 @@
       </v-col>
 
       <v-col v-if="numberOfKeys" cols="12" sm="6" md="4">
-        <SecurityKeyCard isFirst="true" :numberOfKeys="numberOfKeys" :mfaKey="mfa.webauthn[0]"/>
+        <SecurityKeyCard isFirst="true" :numberOfKeys="numberOfKeys" :mfaKey="mfa.keys[0]"/>
       </v-col>
 
       <v-col v-else-if="numberOfKeys === 0">
@@ -97,8 +97,8 @@ export default {
   }),
   computed: {
     hasUnverifiedEmails: vm => vm.alternates.some(m => ! m.verified),
-    additionalKeys: vm => vm.mfa.webauthn.slice(1),
-    numberOfKeys: vm => mfa.webauthn.length
+    additionalKeys: vm => vm.mfa.keys.slice(1),
+    numberOfKeys: vm => vm.mfa.keys.length
   },
   async created() {
     await Promise.all([retrieveMethods(), retrieveMfa()])

--- a/src/profile/ProfileProgress.vue
+++ b/src/profile/ProfileProgress.vue
@@ -6,7 +6,7 @@
       
       <a v-if="complete < 1 && ! profile.alternates.length" href="#/password/recovery">{{ $vuetify.lang.t('$vuetify.profile.progress.addMethod') }}</a>
       <a v-if="complete < 1 && ! profile.mfa.totp.id" href="#/2sv/smartphone/intro">{{ $vuetify.lang.t('$vuetify.profile.progress.addTotp') }}</a>
-      <a v-if="complete < 1 && ! (profile.mfa.u2f.id || profile.mfa.webauthn.id)" href="#/2sv/usb-security-key/intro">{{ $vuetify.lang.t('$vuetify.profile.progress.addSecurityKey') }}</a>
+      <a v-if="complete < 1 && ! (profile.mfa.u2f.id || profile.mfa.webauthn[0]?.id)" href="#/2sv/usb-security-key/intro">{{ $vuetify.lang.t('$vuetify.profile.progress.addSecurityKey') }}</a>
       <a v-if="complete < 1 && ! profile.mfa.backup.id" href="#/2sv/printable-backup-codes/intro">{{ $vuetify.lang.t('$vuetify.profile.progress.addCodes') }}</a>
     </div>
 </template>

--- a/src/profile/ProfileProgress.vue
+++ b/src/profile/ProfileProgress.vue
@@ -6,7 +6,7 @@
       
       <a v-if="complete < 1 && ! profile.alternates.length" href="#/password/recovery">{{ $vuetify.lang.t('$vuetify.profile.progress.addMethod') }}</a>
       <a v-if="complete < 1 && ! profile.mfa.totp.id" href="#/2sv/smartphone/intro">{{ $vuetify.lang.t('$vuetify.profile.progress.addTotp') }}</a>
-      <a v-if="complete < 1 && ! (profile.mfa.u2f.id || profile.mfa.webauthn[0]?.id)" href="#/2sv/usb-security-key/intro">{{ $vuetify.lang.t('$vuetify.profile.progress.addSecurityKey') }}</a>
+      <a v-if="complete < 1 && ! (profile.mfa.u2f.id || profile.mfa.keys[0]?.id)" href="#/2sv/usb-security-key/intro">{{ $vuetify.lang.t('$vuetify.profile.progress.addSecurityKey') }}</a>
       <a v-if="complete < 1 && ! profile.mfa.backup.id" href="#/2sv/printable-backup-codes/intro">{{ $vuetify.lang.t('$vuetify.profile.progress.addCodes') }}</a>
     </div>
 </template>

--- a/src/profile/SecurityKeyCard.vue
+++ b/src/profile/SecurityKeyCard.vue
@@ -3,17 +3,17 @@
     <v-card-title primary-title class="text-break">
       <v-row no-gutters align="center">
         <v-col cols="2">
-          <v-icon :color="meta.created_utc ? 'success' : ''" x-large>mdi-key</v-icon>
+          <v-icon :color="mfaKey ? 'success' : ''" x-large>mdi-key</v-icon>
         </v-col>
         <v-col class="ml-4">
-          <MfaCardLabel :label="label || meta.label || $vuetify.lang.t('$vuetify.profile.index.securityKeyCard.title')" 
-                        :id="meta.id" @new-label="label = $event"/>
+          <MfaCardLabel :label="label || mfaKey.label || $vuetify.lang.t('$vuetify.profile.index.securityKeyCard.title')" 
+                        :id="mfaKey.id" @new-label="label = $event"/>
         </v-col>
       </v-row>
     </v-card-title>
 
     <v-card-text class="flex-grow-1">
-      <Attribute v-if="meta.created_utc" :name="$vuetify.lang.t('$vuetify.profile.index.securityKeyCard.created')" :value="meta.created_utc | format"/>
+      <Attribute v-if="mfaKey.id" :name="$vuetify.lang.t('$vuetify.profile.index.securityKeyCard.created')" :value="mfaKey.created_utc | format"/>
       <v-row v-else>
         <v-col cols="auto">
           <v-icon x-large color="warning" class="pr-3">mdi-alert</v-icon>
@@ -22,19 +22,19 @@
           <em>{{ $vuetify.lang.t('$vuetify.profile.index.securityKeyCard.warning') }}</em>
         </v-col>
       </v-row>
-      <Attribute v-if="meta.last_used_utc" :name="$vuetify.lang.t('$vuetify.profile.index.securityKeyCard.lastUsed')" :value="meta.last_used_utc | format"/>
+      <Attribute v-if="mfaKey.id" :name="$vuetify.lang.t('$vuetify.profile.index.securityKeyCard.lastUsed')" :value="mfaKey.last_used_utc | format"/>
     </v-card-text>
 
     <v-card-actions>
       <v-spacer/>
 
-      <v-btn v-if="meta.created_utc" :href="`#/2sv/change/${meta.id}`" color="primary" outlined>
+      <v-btn v-if="mfaKey.id" :href="`#/2sv/change/${mfaKey.id}`" color="primary" outlined>
         {{ $vuetify.lang.t('$vuetify.profile.index.securityKeyCard.button.change') }}
       </v-btn>
-      <v-btn v-else href="#/2sv/usb-security-key/intro" color="primary" outlined>
+      <v-btn href="#/2sv/usb-security-key/intro" color="primary" outlined>
         {{ $vuetify.lang.t('$vuetify.global.button.add') }}
       </v-btn>
-      <MfaCardRemove v-if="meta.created_utc" :id="meta.id"/>
+      <MfaCardRemove v-if="mfaKey.id" :id="mfaKey.id"/>
     </v-card-actions>
   </v-card>
 </template>
@@ -50,7 +50,7 @@ export default {
     MfaCardLabel,
     MfaCardRemove
   },
-  props: ['meta'],
+  props: ['mfaKey'],
   data: vm => ({
     label: '',
   })

--- a/src/profile/SecurityKeyCard.vue
+++ b/src/profile/SecurityKeyCard.vue
@@ -3,7 +3,7 @@
     <v-card-title primary-title class="text-break">
       <v-row no-gutters align="center">
         <v-col cols="2">
-          <v-icon :color="mfaKey ? 'success' : ''" x-large>mdi-key</v-icon>
+          <v-icon :color="mfaKey.id ? 'success' : ''" x-large>mdi-key</v-icon>
         </v-col>
         <v-col class="ml-4">
           <MfaCardLabel :label="label || mfaKey.label || $vuetify.lang.t('$vuetify.profile.index.securityKeyCard.title')" 
@@ -28,13 +28,13 @@
     <v-card-actions>
       <v-spacer/>
 
-      <v-btn v-if="mfaKey.id" :href="`#/2sv/change/${mfaKey.id}`" color="primary" outlined>
+      <v-btn v-if="mfaKey.id && isFirst" :href="`#/2sv/change/${mfaKey.id}`" color="primary" outlined>
         {{ $vuetify.lang.t('$vuetify.profile.index.securityKeyCard.button.change') }}
       </v-btn>
-      <v-btn href="#/2sv/usb-security-key/intro" color="primary" outlined>
+      <v-btn v-if="isFirst" href="#/2sv/usb-security-key/intro" color="primary" outlined>
         {{ $vuetify.lang.t('$vuetify.global.button.add') }}
       </v-btn>
-      <MfaCardRemove v-if="mfaKey.id" :id="mfaKey.id"/>
+      <MfaCardRemove v-if="mfaKey.id" :id="mfaKey.id" />
     </v-card-actions>
   </v-card>
 </template>
@@ -50,7 +50,7 @@ export default {
     MfaCardLabel,
     MfaCardRemove
   },
-  props: ['mfaKey'],
+  props: ['mfaKey', 'isFirst', 'numberOfKeys'],
   data: vm => ({
     label: '',
   })

--- a/src/profile/SecurityKeyCard.vue
+++ b/src/profile/SecurityKeyCard.vue
@@ -28,13 +28,13 @@
     <v-card-actions>
       <v-spacer/>
 
-      <v-btn v-if="mfaKey.id && isFirst" :href="`#/2sv/change/${mfaKey.id}`" color="primary" outlined>
+      <v-btn v-if="isFirst && numberOfKeys === 1" :href="`#/2sv/change/${mfaKey.id}`" color="primary" outlined>
         {{ $vuetify.lang.t('$vuetify.profile.index.securityKeyCard.button.change') }}
       </v-btn>
       <v-btn v-if="isFirst" href="#/2sv/usb-security-key/intro" color="primary" outlined>
         {{ $vuetify.lang.t('$vuetify.global.button.add') }}
       </v-btn>
-      <MfaCardRemove v-if="mfaKey.id" :id="mfaKey.id" />
+      <MfaCardRemove v-if="numberOfKeys > 1" :id="mfaKey.id" />
     </v-card-actions>
   </v-card>
 </template>


### PR DESCRIPTION
I have~n't~ been able to succesfully test this against the api and broker, but ~only with mocked keys~ this doesn't include the new endpoint. 
We will also need a translation for "security keys" in a subsequent PR before release.

If you want to try testing just use the following images in the docker-compose file:
broker:
    image: silintl/idp-id-broker:dev-multiwebauthn
api:
    image: silintl/idp-pw-api:featuremulti-webauthn

![image](https://user-images.githubusercontent.com/70765247/205524050-cd8809b0-e7fe-4f33-a5f0-ce87dcaafc3d.png)

with more keys

![image](https://user-images.githubusercontent.com/70765247/205524393-7ab059b0-f0d2-4394-b911-9cd459a1be10.png)

