### PR TITLE
refresh form to avoid freezing with good password after old password

### DIFF
--- a/src/password/Create.vue
+++ b/src/password/Create.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProfileWizard ref="wizard">
+  <ProfileWizard ref="wizard" :key="wizardKey">
     <BasePage>
       <template v-slot:header>
         {{ $vuetify.lang.t('$vuetify.password.create.header', $root.idpConfig.idpName) }}
@@ -59,6 +59,7 @@ export default {
     ProfileWizard,
   },
   data: vm => ({
+    wizardKey: 0, // This is used to refresh the form, instead of leaving it frozen after a re-used password
     password: vm.$root.$data.password || '',
     rules: [
       v => required(v, vm),
@@ -74,6 +75,9 @@ export default {
     isGood: vm => vm.password && vm.$refs.form && vm.$refs.form.validate(),
   },
   methods: {
+    forceRerender() { // This is used to refresh the form, instead of leaving it frozen after a re-used password
+      this.wizardKey += 1;
+    },
     async save() {
       if (this.$refs.form.validate()) {
         try {
@@ -104,6 +108,11 @@ export default {
   },
   watch: {
     password: function () {
+      // This is used to refresh the form, instead of leaving it frozen after a re-used password
+      if (this.password == '') {
+        this.forceRerender()
+      }
+
       if (this.isGood) {
         this.errors.splice(0)
       }


### PR DESCRIPTION
If you try to change your password and enter one of your previous passwords, you get the proper error message. But, if you stay on the form and then enter a good password, nothing happens at all.

This refreshes the wizard to allow you to enter an acceptable password without it all freezing up.

I just found this kind of solution by googling. If there is a better way to do it, please take over this branch and make the changes you want.

Also, this probably needs more testing than I gave it.