### PR TITLE
Reset the list of relevant steps each time so it is properly initialized

### DIFF
--- a/src/profile/steps.js
+++ b/src/profile/steps.js
@@ -9,16 +9,16 @@ const store = {
 export default {
   steps: store.steps,
   async init() {
-    if (store.steps.length == 0) {
-      if (Vue.prototype.$user.auth_type == 'login') {
-        await Promise.all([retrieveMethods(), retrieveMfa()])
-      }
-      
-      store.steps.push(...allSteps.filter(step => step.isRelevant(Vue.prototype.$user, recoveryMethods.alternates, mfa)))
+    store.steps.splice(0)
 
-      for (let i = 0; i < store.steps.length; i++) {
-        Object.assign(store.steps[i], { id: i + 1, state: '' })
-      }
+    if (Vue.prototype.$user.auth_type == 'login') {
+      await Promise.all([retrieveMethods(), retrieveMfa()])
+    }
+
+    store.steps.push(...allSteps.filter(step => step.isRelevant(Vue.prototype.$user, recoveryMethods.alternates, mfa)))
+
+    for (let i = 0; i < store.steps.length; i++) {
+      Object.assign(store.steps[i], { id: i + 1, state: '' })
     }
   },
   forPath(path) {


### PR DESCRIPTION
### Fixed
- Reset the list of relevant steps each time so it is properly initialized

---

Without this, going to a step, hitting the browser's Back button, then going to another step (e.g. change password, back, change password recovery) gave this error:
`Cannot read properties of undefined (reading 'id') on Profile UI`

It seemed to be because currentStep was undefined because the current URL path didn't match any of the "relevant" steps (since they hadn't been updated). See ProfileWizard.vue:
```vue
  <v-stepper v-if="currentStep.id" ...
```

**NOTE:** [Hiding whitespace](https://github.com/silinternational/idp-profile-ui/pull/149/files?w=1) helps this diff.

[IDP-947](https://itse.youtrack.cloud/issue/IDP-947)