### PR TITLE
Release 5.3.4 - Fix ProfileWizard stepper after use of browser's Back button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4257,9 +4257,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -5367,9 +5367,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -5377,7 +5377,7 @@
         "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",

--- a/src/profile/steps.js
+++ b/src/profile/steps.js
@@ -9,16 +9,16 @@ const store = {
 export default {
   steps: store.steps,
   async init() {
-    if (store.steps.length == 0) {
-      if (Vue.prototype.$user.auth_type == 'login') {
-        await Promise.all([retrieveMethods(), retrieveMfa()])
-      }
-      
-      store.steps.push(...allSteps.filter(step => step.isRelevant(Vue.prototype.$user, recoveryMethods.alternates, mfa)))
+    store.steps.splice(0)
 
-      for (let i = 0; i < store.steps.length; i++) {
-        Object.assign(store.steps[i], { id: i + 1, state: '' })
-      }
+    if (Vue.prototype.$user.auth_type == 'login') {
+      await Promise.all([retrieveMethods(), retrieveMfa()])
+    }
+
+    store.steps.push(...allSteps.filter(step => step.isRelevant(Vue.prototype.$user, recoveryMethods.alternates, mfa)))
+
+    for (let i = 0; i < store.steps.length; i++) {
+      Object.assign(store.steps[i], { id: i + 1, state: '' })
     }
   },
   forPath(path) {


### PR DESCRIPTION
### Fixed
- Reset the list of relevant steps each time so it is properly initialized.
  * Without this, using the browser's Back button leaves the old list of steps, which may or may not match the current URL path when the user clicks a tile from their profile dashboard.
  * Unfortunately, with this the list of steps (most noticeably during initial onboarding) doesn't keep the completed steps in the progress bar at the top. A separate issue is being added to our backlog about that bug.