### PR TITLE
Update docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.0'
-
 services:
   node:
     image: node:18-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ services:
       - '8080:80'
     depends_on:
       - profileDb
-      - memcache
       - broker
       - zxcvbn
       - idp
@@ -66,7 +65,6 @@ services:
       PASSWORD_RULE_minLength: '10'
       PASSWORD_RULE_maxLength: '255'
       PASSWORD_RULE_minScore: '3'
-      MEMCACHE_CONFIG1_host: 'memcache'
     command: [ 'bash', '-c', 'whenavail profileDb 3306 60 ./yii migrate --interactive=0 && ./run.sh' ]
 
   profileDb:
@@ -89,11 +87,6 @@ services:
       PMA_HOST: 'profileDb'
       PMA_USER: 'user'
       PMA_PASSWORD: 'pass'
-
-  memcache:
-    image: memcached:1.4-alpine
-    ports:
-      - "11211"  
 
   zxcvbn:
     image: wcjr/zxcvbn-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   api:
     image: silintl/idp-pw-api:develop
+    platform: linux/amd64
     ports:
       - '8080:80'
     depends_on:
@@ -88,12 +89,14 @@ services:
 
   zxcvbn:
     image: wcjr/zxcvbn-api
+    platform: linux/amd64
     ports:
       - '3000'
   
   proxy:
     # https://github.com/silinternational/traefik-https-proxy
     image: silintl/traefik-https-proxy
+    platform: linux/amd64
     ports:
       - '80:80'
       - '443:443'
@@ -118,6 +121,7 @@ services:
 
   broker:
     image: silintl/idp-id-broker:develop
+    platform: linux/amd64
     volumes:
       - ./development/m991231_235959_insert_test_users.php:/data/console/migrations/m991231_235959_insert_test_users.php
     ports:
@@ -177,6 +181,7 @@ services:
 
   idp:
     image: silintl/ssp-base:develop
+    platform: linux/amd64
     volumes:
       - ./development/authsources.php:/data/vendor/simplesamlphp/simplesamlphp/config/authsources.php
       - ./development/saml20-idp-hosted.php:/data/vendor/simplesamlphp/simplesamlphp/metadata/saml20-idp-hosted.php
@@ -247,6 +252,7 @@ services:
 
   dynamo:
     image: amazon/dynamodb-local
+    platform: linux/amd64
     ports:
       - "8010:8000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       MYSQL_PASSWORD: 'pass'
 
   profilePhpmyadmin:
-    image: phpmyadmin/phpmyadmin
+    image: phpmyadmin:5
     ports:
       - '8081:80'
     depends_on:
@@ -169,7 +169,7 @@ services:
       MYSQL_PASSWORD: 'pass'
 
   brokerPhpmyadmin:
-    image: phpmyadmin/phpmyadmin
+    image: phpmyadmin:5
     ports:
       - '8091:80'
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       SUPPORT_URL: 'https://www.example.org/support'
       SUPPORT_FEEDBACK: 'https://www.example.org/support-feedback'
       UI_URL: 'https://profile.gtis.guru/#'
-      LOGO_URL: 'https://www.sil.org'
+      LOGO_URL: 'https://www.example.org/logo.png'
       UI_CORS_ORIGIN: 'https://profile.gtis.guru'
       ACCESS_TOKEN_HASH_KEY: 'KEY4TESTING'
       ZXCVBN_API_BASEURL: 'http://zxcvbn:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,6 @@ services:
       SUPPORT_URL: 'https://www.example.org/support'
       SUPPORT_FEEDBACK: 'https://www.example.org/support-feedback'
       UI_URL: 'https://profile.gtis.guru/#'
-      LOGO_URL: 'https://www.example.org/logo.png'
       UI_CORS_ORIGIN: 'https://profile.gtis.guru'
       ACCESS_TOKEN_HASH_KEY: 'KEY4TESTING'
       ZXCVBN_API_BASEURL: 'http://zxcvbn:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     command: [ 'bash', '-c', 'whenavail profileDb 3306 60 ./yii migrate --interactive=0 && ./run.sh' ]
 
   profileDb:
-    image: mariadb:latest
+    image: mariadb:10
     ports:
       - '3306'
     environment:
@@ -159,7 +159,7 @@ services:
     command: [ 'bash', '-c', 'whenavail brokerDb 3306 60 ./yii migrate --interactive=0 && ./run.sh' ]
 
   brokerDb:
-    image: mariadb:latest
+    image: mariadb:10
     ports:
       - '3306'
     environment:
@@ -221,7 +221,7 @@ services:
     command: [ 'bash', '-c', 'whenavail silAuthDb 3306 60 ./run-idp.sh' ]
 
   silAuthDb:
-    image: mariadb:latest
+    image: mariadb:10
     ports:
       - '3306'
     environment:


### PR DESCRIPTION
### Fixed
- Use example.org for dummy domain name/URL in docker-compose.yml file
- Use the official phpMyAdmin image for local development
- Use a specific major version of MariaDB for local development
- Specify `platform` for local development images that are single-platform
- Remove unneeded `version` line at top of docker-compose.yml file
- Remove references to memcache for local development