### PR TITLE
IDP-720  update webauthn dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@vue/cli-plugin-babel": "^5.0.8",
         "@vue/cli-service": "^5.0.8",
         "babel-plugin-transform-imports": "^2.0.0",
+        "prettier": "^3.3.3",
         "rimraf": "^3.0.2",
         "sass": "^1.53.0",
         "stylus": "^0.58.1",
@@ -3119,6 +3120,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/@vue/component-compiler-utils/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@vue/component-compiler-utils/node_modules/yallist": {
@@ -8747,15 +8764,15 @@
       "dev": true
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "optional": true,
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -10604,6 +10621,21 @@
       },
       "optionalDependencies": {
         "prettier": "^1.18.2 || ^2.0.0"
+      }
+    },
+    "node_modules/vue/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "optional": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/vuetify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/polyfill": "^7.12.1",
         "@sentry/vue": "^7.113.0",
-        "@simplewebauthn/browser": "^4.1.0",
+        "@simplewebauthn/browser": "^9",
         "@zxcvbn-ts/core": "^3.0.4",
         "@zxcvbn-ts/language-common": "^3.0.4",
         "@zxcvbn-ts/language-en": "^3.0.2",
@@ -2133,9 +2133,17 @@
       "dev": true
     },
     "node_modules/@simplewebauthn/browser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-4.1.0.tgz",
-      "integrity": "sha512-tIsEfShC1rrqrsNb44tOFuSriAFCz4tkdDnCjHfn2rYxgz+t+yqEvuIRfJHQpFrWSnZPdsjrAHtasj6lzfGI6w=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-9.0.1.tgz",
+      "integrity": "sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw==",
+      "dependencies": {
+        "@simplewebauthn/types": "^9.0.1"
+      }
+    },
+    "node_modules/@simplewebauthn/types": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-9.0.1.tgz",
+      "integrity": "sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w=="
     },
     "node_modules/@soda/friendly-errors-webpack-plugin": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@vue/cli-plugin-babel": "^5.0.8",
     "@vue/cli-service": "^5.0.8",
     "babel-plugin-transform-imports": "^2.0.0",
+    "prettier": "^3.3.3",
     "rimraf": "^3.0.2",
     "sass": "^1.53.0",
     "stylus": "^0.58.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
     "@sentry/vue": "^7.113.0",
-    "@simplewebauthn/browser": "^4.1.0",
+    "@simplewebauthn/browser": "^9",
     "@zxcvbn-ts/core": "^3.0.4",
     "@zxcvbn-ts/language-common": "^3.0.4",
     "@zxcvbn-ts/language-en": "^3.0.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -68,7 +68,7 @@ export default {
         this.message = error.message
 
         throw error
-      }
+      },
     )
   },
   created() {

--- a/src/global/Loading.vue
+++ b/src/global/Loading.vue
@@ -24,7 +24,7 @@ export default {
         this.loading--
 
         throw error
-      }
+      },
     )
   },
 }

--- a/src/global/mfa.js
+++ b/src/global/mfa.js
@@ -34,19 +34,19 @@ export const retrieve = async () => {
 
   mfa.totp = Object.assign(
     {},
-    all.find((m) => m.type === 'totp')
+    all.find((m) => m.type === 'totp'),
   )
   mfa.u2f = Object.assign(
     {},
-    all.find((m) => m.type === 'u2f')
+    all.find((m) => m.type === 'u2f'),
   )
   mfa.keys = Object.assign(
     {},
-    all.find((m) => m.type === 'webauthn')
+    all.find((m) => m.type === 'webauthn'),
   )
   mfa.backup = Object.assign(
     {},
-    all.find((m) => m.type === 'backupcode')
+    all.find((m) => m.type === 'backupcode'),
   )
 
   mfa.numVerified = numOfVerifiedMfas(mfa) // currently, the api only returns verified mfas

--- a/src/plugins/api.js
+++ b/src/plugins/api.js
@@ -18,7 +18,7 @@ api.interceptors.request.use(
     const e = (error.response && error.response.data) || error
 
     throw e
-  }
+  },
 )
 
 api.interceptors.response.use(
@@ -31,7 +31,7 @@ api.interceptors.response.use(
     }
 
     throw e
-  }
+  },
 )
 
 Vue.use((theVue) => {


### PR DESCRIPTION
## Fix
 - update "@simplewebauthn/browser": "^9",

[IDP-720](https://itse.youtrack.cloud/issue/IDP-720)

Note: I was still unable to login to an account that had the Iphone passkey created first then a Yubikey, but in creating new Webauthn credentials this didn't happen. It may be that some accounts are locked out due to a scenario like this if they don't have other 2sv options.