### PR TITLE
dont send 401, 403, 404 errors to sentry

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,13 @@ if (location.hostname !== 'profile.gtis.guru') {
     // plus for 100% of sessions with an error
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0,
+    beforeSend(event, hint) {
+      const status = hint.originalException.status
+      if (status === 404 || status === 401 || status === 403) {
+        return null
+      }
+      return event
+    },
   })
 }
 


### PR DESCRIPTION
[ITSE-1585](https://itse.youtrack.cloud/issue/ITSE-1585) Catch initial api requests when not logged in or 404 error
---

### Fixed

- Fix sending irrelevant errors to Sentry
