### PR TITLE
remove backticks from primary.value

### DIFF
--- a/src/password/Recovery.vue
+++ b/src/password/Recovery.vue
@@ -6,7 +6,7 @@
       <p>{{ $t('password.recovery.explanation') }}</p>
 
       <p v-if="alternates.length">{{ $t('password.recovery.atLeastOneRecovery') }}</p>
-      <p v-else>{{ $t('password.recovery.info', [`primary.value`]) }}</p>
+      <p v-else>{{ $t('password.recovery.info', [primary.value]) }}</p>
 
       <p v-if="!alternates.length">
         {{ $t('password.recovery.advice') }}


### PR DESCRIPTION
[IDP-1460](https://itse.youtrack.cloud/issue/IDP-1460) minor bug on IIDP alternate email request page

---

### Fixed

- Fixed incorrect rendering of primary email address on the /password/recovery page.



### Feature branch checklist

- [x] Documentation (README, etc.)
- [x] Run `make format` ~and `make depsupdate`~
