### PR TITLE
Update Node.js version in workflow to 22.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '18.x'
+        node-version: '22.x'
 
     - name: Install Dependencies
       run: npm ci


### PR DESCRIPTION
[ITSE-2693](https://support.gtis.sil.org/issue/ITSE-2693) Update GitHub actions that force Node v20

---

- Change the workflow to Node version 22 to match the version used on Cloudflare pages.