### PR TITLE
autofill username if found in the query string on forgot password page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -187,7 +187,7 @@
     },
     "forgot": {
       "header": "Forgot my password",
-      "unameInput": "Enter your {0} username",
+      "unameInput": "Enter your {0} username or email",
       "required": "A username is required",
       "clickOnly": "Please click me to send a link",
       "button": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -187,7 +187,7 @@
     },
     "forgot": {
       "header": "He olvidado mi contraseña",
-      "unameInput": "Ingrese su {0} nombre de usuario",
+      "unameInput": "Ingrese su nombre de usuario o correo electrónico de {0}",
       "required": "Se requiere nombre de usuario",
       "clickOnly": "Por favor, haz clic para enviar un enlace",
       "button": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -187,7 +187,7 @@
     },
     "forgot": {
       "header": "J'ai oublié mon mot de passe",
-      "unameInput": "Saisissez votre nom d'utilisateur {0}",
+      "unameInput": "Saisissez votre nom d'utilisateur ou votre email {0}",
       "required": "Un nom d’utilisateur est requis",
       "clickOnly": "S’il vous plaît cliquez sur moi pour envoyer un lien",
       "button": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -187,7 +187,7 @@
     },
     "forgot": {
       "header": "비밀번호를 잊어버렸습니다",
-      "unameInput": "{0} 사용자 이름을 입력하십시오.",
+      "unameInput": "{0} 사용자 이름 또는 이메일을 입력하세요.",
       "required": "아이디(username) 는 필수 입력사항입니다",
       "clickOnly": "링크를 보내려면 여기를 클릭하십시오.",
       "button": {

--- a/src/password/Forgot.vue
+++ b/src/password/Forgot.vue
@@ -43,9 +43,24 @@ export default {
     usedEnterKey: false,
   }),
   created() {
+    this.prefillUsernameFromQuery()
     loadRecaptchaApi(this.recaptchaLoaded)
   },
   methods: {
+    prefillUsernameFromQuery() {
+      const { username } = this.$route.query
+
+      // Vue Router query params can be a string or an array of strings.
+      const queryUsername = Array.isArray(username) ? username[0] : username
+
+      if (typeof queryUsername === 'string') {
+        const trimmed = queryUsername.trim()
+
+        if (trimmed) {
+          this.uname = trimmed
+        }
+      }
+    },
     recaptchaLoaded() {
       grecaptcha.render(document.querySelector('.g-recaptcha'), {
         sitekey: `${import.meta.env.VITE_RECAPTCHA_ID}`,


### PR DESCRIPTION
[IDP-1944](https://support.gtis.sil.org/issue/IDP-1944) Pre-fill Forgot Password

---

### Added

- Added a feature to pre-fill the username field if it is found in a query string parameter.
- Added the word "email" to the forgot password form field.

### Feature branch checklist

- [ ] Documentation (README, etc.)
- [x] Run `make format` and `make depsupdate`
