### PR TITLE
Set X-Frame-Options to DENY

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -34,6 +34,14 @@ export default defineConfig(({ mode }) => {
         clientPort: 443,
         host: 'profile.gtis.guru',
       },
+      headers: {
+        'X-Frame-Options': 'DENY',
+      },
+    },
+    preview: {
+      headers: {
+        'X-Frame-Options': 'DENY',
+      },
     },
     define: {
       __APP_VERSION__: JSON.stringify(env.UI_VERSION),


### PR DESCRIPTION
### [IDP-2035](https://support.gtis.sil.org/issue/IDP-2035) Use "X-Frame-Options" header on idp-profile-ui, set to DENY
This PR adds the `X-Frame-Options` header set to `DENY` for both the development server and preview configurations in Vite. This prevents the application from being embedded in iframes.
