### PR TITLE
Show user's own email on profile dashboard

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -70,6 +70,7 @@
     "index": {
       "header": "My {0} Identity",
       "username": "Username: ",
+      "email": "Email: ",
       "lastLogin": "Last login: ",
       "manager": "Recovery contact: ",
       "2sv": "2-Step Verification",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -70,6 +70,7 @@
     "index": {
       "header": "Mi {0} identidad",
       "username": "Nombre de usuario: ",
+      "email": "Correo electrónico: ",
       "lastLogin": "Último inicio de sesión: ",
       "manager": "Contacto de recuperación: ",
       "2sv": "Verificación de 2 pasos",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -70,6 +70,7 @@
     "index": {
       "header": "Mon identité {0}",
       "username": "Nom d'utilisateur : ",
+      "email": "E-mail : ",
       "lastLogin": "Dernière connexion : ",
       "manager": "Contact de récupération: ",
       "2sv": "Vérification en 2 Étapes",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -70,6 +70,7 @@
     "index": {
       "header": "내 {0} ID",
       "username": "사용자이름 : ",
+      "email": "이메일: ",
       "lastLogin": "마지막 로그인 ",
       "manager": "복구 담당자: ",
       "2sv": "2단계 인증",

--- a/src/profile/Index.vue
+++ b/src/profile/Index.vue
@@ -7,6 +7,7 @@
     <v-row>
       <v-col cols="6">
         <Attribute :name="$t('profile.index.username')" :value="user.idp_username" sameline />
+        <Attribute :name="$t('profile.index.email')" :value="user.email" sameline />
         <Attribute :name="$t('profile.index.lastLogin')" :value="formatDate(user.last_login)" sameline />
         <Attribute :name="$t('profile.index.manager')" :value="user.manager_email" sameline />
       </v-col>


### PR DESCRIPTION
[IDP-961](https://support.gtis.sil.org/issue/IDP-961) profile manager doesn't show user email address

---

### Added

- Profile dashboard now displays the user's own email address, below the username.
