### PR TITLE
update idp-pw-api to version 10 in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,7 +25,7 @@ services:
       - api
 
   api:
-    image: ghcr.io/sil-org/idp-pw-api:9
+    image: ghcr.io/sil-org/idp-pw-api:10
     platform: linux/amd64
     ports:
       - '8080:80'
@@ -139,6 +139,7 @@ services:
     environment:
       APP_ENV: 'dev'
       API_ACCESS_KEYS: 'local-testing-abc123'
+      HIBP_CHECK_ON_LOGIN: 'false'
       MIGRATE_PW_FROM_LDAP: 'false'
       MYSQL_HOST: 'brokerDb'
       MYSQL_DATABASE: 'broker'


### PR DESCRIPTION
[IDP-2207](https://support.gtis.sil.org/issue/IDP-2207) update image version in compose.yaml in idp-profile-ui

---

### Changed

- Updated idp-pw-api to version 10 in compose.yaml

### Fixed

- Set `HIBP_CHECK_ON_LOGIN` to false in compose.yaml to prevent lockout due to a simple default password ("a") for the default user in the local dev database.

### Feature branch checklist

- [ ] Documentation (README, etc.)
- [ ] Run `make format` and `make depsupdate`
