### PR TITLE
Prevent client-side form validation errors from logging to Sentry

### DIFF
--- a/src/2sv/authenticator/VerifyQrCode.vue
+++ b/src/2sv/authenticator/VerifyQrCode.vue
@@ -42,6 +42,7 @@
 <script>
 import ProfileWizard from '@/profile/ProfileWizard.vue'
 import { verify } from '@/global/mfa'
+import eventBus from '@/eventBus'
 
 export default {
   components: {
@@ -71,7 +72,7 @@ export default {
         }
       } else {
         errors.forEach((error) => {
-          throw Error(error.errorMessages.join('\n'))
+          eventBus.emit('error', { message: error.errorMessages.join('\n') })
         })
       }
     },

--- a/src/password/Confirm.vue
+++ b/src/password/Confirm.vue
@@ -58,6 +58,7 @@
 <script>
 import { usePasswordStore } from './password'
 import ProfileWizard from '@/profile/ProfileWizard.vue'
+import eventBus from '@/eventBus'
 
 export default {
   name: 'PasswordConfirm',
@@ -103,7 +104,7 @@ export default {
         this.$router.push('/password/saved')
       } else {
         errors.forEach((error) => {
-          throw Error(error.errorMessages.join('\n'))
+          eventBus.emit('error', { message: error.errorMessages.join('\n') })
         })
       }
     },

--- a/src/password/Create.vue
+++ b/src/password/Create.vue
@@ -96,6 +96,7 @@
 <script>
 import { usePasswordStore } from './password'
 import ProfileWizard from '@/profile/ProfileWizard.vue'
+import eventBus from '@/eventBus'
 import { zxcvbn, zxcvbnOptions } from '@zxcvbn-ts/core'
 import * as zxcvbnCommonPackage from '@zxcvbn-ts/language-common'
 import * as zxcvbnEnPackage from '@zxcvbn-ts/language-en'
@@ -178,7 +179,7 @@ export default {
         }
       } else {
         errors.forEach((error) => {
-          throw Error(error.errorMessages.join('\n'))
+          eventBus.emit('error', { message: error.errorMessages.join('\n') })
         })
       }
     },

--- a/src/password/Forgot.vue
+++ b/src/password/Forgot.vue
@@ -35,6 +35,8 @@
 </template>
 
 <script>
+import eventBus from '@/eventBus'
+
 export default {
   name: 'ForgotPassword',
   data: () => ({
@@ -93,7 +95,7 @@ export default {
         }
       } else {
         errors.forEach((error) => {
-          throw Error(error.errorMessages.join('\n'))
+          eventBus.emit('error', { message: error.errorMessages.join('\n') })
         })
       }
     },

--- a/src/password/Recovery.vue
+++ b/src/password/Recovery.vue
@@ -91,6 +91,7 @@
 <script>
 import ProfileWizard from '@/profile/ProfileWizard.vue'
 import { recoveryMethods, add, remove } from '@/global/recoveryMethods'
+import eventBus from '@/eventBus'
 
 export default {
   name: 'PasswordRecovery',
@@ -117,7 +118,7 @@ export default {
         this.$root.$emit('clear-messages') // listener in App.vue (this is a temporary hack hopefully)
       } else {
         errors.forEach((error) => {
-          throw Error(error.errorMessages.join('\n'))
+          eventBus.emit('error', { message: error.errorMessages.join('\n') })
         })
       }
     },

--- a/src/profile/MfaCardLabel.vue
+++ b/src/profile/MfaCardLabel.vue
@@ -40,6 +40,7 @@
 
 <script>
 import { change, changeWebauthn } from '@/global/mfa'
+import eventBus from '@/eventBus'
 
 export default {
   props: {
@@ -79,7 +80,8 @@ export default {
     },
     async save() {
       if (this.newLabel.length > 65) {
-        throw Error(this.$t('global.mfaLabelTooLong'))
+        eventBus.emit('error', { message: this.$t('global.mfaLabelTooLong') })
+        return
       }
       const mfa = this.isWebauthn
         ? await changeWebauthn(this.mfaId, this.keyId, {


### PR DESCRIPTION
### [IDP-2028](https://support.gtis.sil.org/issue/IDP-2028) Fix logging for idp-profile-ui, "That password does not match your previous one"
### [IDP-2027](https://support.gtis.sil.org/issue/IDP-2027) Fix logging for idp-profile-ui, a new password is required

---

Replaces throw Error(...) statements with eventBus.emit('error', ...) across form handling components. This handles validation and user feedback without triggering unhandled exceptions that get logged to Sentry.

### Changed
- Updated `VerifyQrCode.vue`, `Confirm.vue`, `Create.vue`, `Forgot.vue`, `Recovery.vue`, and `MfaCardLabel.vue` to emit error events via eventBus instead of throwing exceptions.

### Feature branch checklist

- [ ] Documentation (README, etc.)
- [ ] Run `make format` and `make depsupdate`
