### PR TITLE
minor fixes in the development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 start: deps mfaapi
 	docker compose pull
-	docker compose up -d --build proxy brokerPhpmyadmin
+	docker compose up -d proxy brokerPhpmyadmin
 
 deps:
 	docker compose run --rm node npm install
@@ -20,7 +20,7 @@ phpmyadmin:
 	docker compose up -d brokerPhpmyadmin profilePhpmyadmin
 
 mfaapi:
-	docker compose up -d --build mfaapi
+	docker compose up -d mfaapi
 
 clean:
 	docker compose run --rm node npm run clean
@@ -32,3 +32,6 @@ format:
 
 lint:
 	docker compose run --rm node npm run lint
+
+build:
+	docker compose build

--- a/compose.yaml
+++ b/compose.yaml
@@ -161,6 +161,12 @@ services:
       MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
       MFA_WEBAUTHN_rpId: gtis.guru
     command: ['bash', '-c', './yii migrate --interactive=0 && ./run.sh']
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "localhost/site/status"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   brokerDb:
     image: mariadb:10

--- a/dynamorestart/DynamoRestart.php
+++ b/dynamorestart/DynamoRestart.php
@@ -34,9 +34,7 @@ class DynamoRestart
             try {
                 $this->client->deleteTable(['TableName' => $table]);
             } catch (\Exception $e) {
-                if (!str_contains($e->getMessage(), "400 Bad Request")) {
-                    throw $e;
-                }
+                // proceed without interruption in case no table exists yet
             }
         }
 


### PR DESCRIPTION

### Changed

- Don't rebuild containers in `make start` because it is a lengthy process and all our other repos skip this. Added a separate `build` make target for convenience.

### Fixed

- Added a health check on the broker container.
- Don't fail the DynamoDB setup at the table delete step if a table doesn't exist yet.

### Feature branch checklist

- [ ] Documentation (README, etc.)
- [ ] Run `make format` and `make depsupdate`
