### PR TITLE
Fix undefined is not an object sentry error in email submission

### DIFF
--- a/src/password/Recovery.vue
+++ b/src/password/Recovery.vue
@@ -132,16 +132,29 @@ export default {
       this.$refs.wizard.next()
     },
     isAlias(email, primaryEmail) {
-      const normalizeEmail = (email) => {
-        const [localPart, domain] = email.split('@')
-        const cleanedLocalPart = localPart.includes('+') ? localPart.split('+')[0] : localPart
-        const normalizedLocalPart = cleanedLocalPart.replace(/\./g, '')
+      if (typeof email !== 'string' || typeof primaryEmail !== 'string') {
+        return false
+      }
+
+      const normalizeEmail = (value) => {
+        const [localPart, domain] = value.split('@')
+
+        if (!localPart || !domain) {
+          return ''
+        }
+
+        const normalizedLocalPart = localPart
+          .split('+')[0]
+          .replace(/\./g, '')
 
         return `${normalizedLocalPart}@${domain}`.toLowerCase()
       }
 
-      return normalizeEmail(email) === normalizeEmail(primaryEmail)
-    },
+      const normalizedEmail = normalizeEmail(email)
+      const normalizedPrimary = normalizeEmail(primaryEmail)
+
+      return normalizedEmail !== '' && normalizedEmail === normalizedPrimary
+    }
   },
 }
 </script>

--- a/src/password/Recovery.vue
+++ b/src/password/Recovery.vue
@@ -143,9 +143,7 @@ export default {
           return ''
         }
 
-        const normalizedLocalPart = localPart
-          .split('+')[0]
-          .replace(/\./g, '')
+        const normalizedLocalPart = localPart.split('+')[0].replace(/\./g, '')
 
         return `${normalizedLocalPart}@${domain}`.toLowerCase()
       }
@@ -154,7 +152,7 @@ export default {
       const normalizedPrimary = normalizeEmail(primaryEmail)
 
       return normalizedEmail !== '' && normalizedEmail === normalizedPrimary
-    }
+    },
   },
 }
 </script>


### PR DESCRIPTION
[IDP-2211](https://support.gtis.sil.org/issue/IDP-2211) Fix "undefined is not an object (evaluating 'r.split')" error
### Reason
`isAlias` in `src/password/Recovery.vue` called `.split('@')` on inputs without checking if `email` or `primaryEmail` was `undefined`. This happened when primary email data hadn't loaded yet or when the field was empty, causing the app to log Sentry errors.
### Fix
Added checks in `isAlias` to return `false` if either email argument is missing, undefined, or is not a string before attempting to split the email address.

### Feature branch checklist

- [ ] Documentation (README, etc.)
- [ ] Run `make format` and `make depsupdate`
