### PR TITLE
Rename phpmyadmin target to adminer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ logs:
 	docker compose logs
 	docker compose exec idp cat /var/log/apache2/error.log
 
-phpmyadmin:
+adminer:
 	docker compose up -d adminer
 
 mfaapi:


### PR DESCRIPTION
[IDP-2128](https://support.gtis.sil.org/issue/IDP-2128) Switch IDP over to use Adminer

---

### Fixed

- Rename the Makefile `phpmyadmin` target to `adminer`
